### PR TITLE
Support config-enabled production usage & add pretty formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+## [0.3.0] - 2025-10-29
+
+- Add production mode support via `enable_in_production` configuration option
+- Add beautiful Rails-branded error page styling with red gradient header
+- Add code context section showing 3 lines before/after the error with highlighting
+- Add numbered stack trace with dark theme
+- Remove "View full Rails error page" button (simplified design)
+- Improve stack trace extraction to work reliably in both dev and production
+- Add `ShowExceptions` middleware for production error handling
+
 ## [0.2.0] - 2025-10-25
 
 - Add a "View full Rails error page" button to the HTML view.

--- a/lib/concise_errors.rb
+++ b/lib/concise_errors.rb
@@ -7,6 +7,7 @@ require_relative "concise_errors/version"
 require_relative "concise_errors/configuration"
 require_relative "concise_errors/formatter"
 require_relative "concise_errors/debug_exceptions"
+require_relative "concise_errors/show_exceptions"
 
 # ConciseErrors exposes configuration helpers and loads the custom error middleware.
 module ConciseErrors

--- a/lib/concise_errors/configuration.rb
+++ b/lib/concise_errors/configuration.rb
@@ -6,7 +6,7 @@ module ConciseErrors
     DEFAULT_STACK_LINES = 10
     DEFAULT_FORMAT = :text
 
-    attr_accessor :stack_trace_lines, :enabled, :logger, :application_root, :cleaner, :full_error_param
+    attr_accessor :stack_trace_lines, :enabled, :logger, :application_root, :cleaner, :full_error_param, :enable_in_production
 
     def initialize
       reset!
@@ -18,6 +18,10 @@ module ConciseErrors
 
     def enabled?
       enabled != false
+    end
+
+    def enable_in_production?
+      enable_in_production == true
     end
 
     def format=(value)
@@ -32,6 +36,7 @@ module ConciseErrors
       @application_root = nil
       @cleaner = nil
       @full_error_param = "concise_errors_full"
+      @enable_in_production = false
     end
   end
 end

--- a/lib/concise_errors/formatter.rb
+++ b/lib/concise_errors/formatter.rb
@@ -43,13 +43,27 @@ module ConciseErrors
         <html lang="en">
           <head>
             <meta charset="utf-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1">
             <title>#{html_escape(heading_line)}</title>
+            #{error_page_styles}
           </head>
           <body>
-            <h1>#{html_escape(heading_line)}</h1>
-            <p>#{html_escape(status_line)}</p>
-            <pre>#{html_escape(truncated_trace.join("\n"))}</pre>
-            #{full_error_controls}
+            <div class="container">
+              <div class="error-header">
+                <h1>#{html_escape(wrapper.exception_class_name)}</h1>
+                <p class="error-message">#{html_escape(wrapper.message)}</p>
+                <p class="status-line">#{html_escape(status_line)}</p>
+              </div>
+              
+              #{code_context_section}
+              
+              <div class="trace-section">
+                <h2>Stack Trace</h2>
+                <pre class="trace">#{html_escape(formatted_trace)}</pre>
+              </div>
+              
+              #{full_error_button_dev_only}
+            </div>
           </body>
         </html>
       HTML
@@ -66,12 +80,29 @@ module ConciseErrors
     end
 
     def truncated_trace
-      full_trace = Array(wrapper.exception_trace).map { |line| sanitize_trace(line) }
+      full_trace = raw_trace.map { |line| sanitize_trace(line) }
       limit = configuration.stack_trace_lines
 
       return full_trace if limit.nil? || limit <= 0 || full_trace.size <= limit
 
       full_trace.first(limit) + [Kernel.format(OMITTED_SUFFIX, count: full_trace.size - limit)]
+    end
+    
+    def raw_trace
+      # Try multiple ways to get the trace
+      trace = wrapper.exception_trace
+      
+      if trace.nil? || trace.empty?
+        exception = wrapper.exception
+        trace = exception&.backtrace || []
+      end
+      
+      # Last resort: try application_trace
+      if trace.empty? && wrapper.respond_to?(:application_trace)
+        trace = wrapper.application_trace || []
+      end
+      
+      Array(trace)
     end
 
     def html_escape(string)
@@ -94,102 +125,40 @@ module ConciseErrors
       line.sub(%r{\A#{Regexp.escape(root)}/?}, "./")
     end
 
-    def full_error_controls
+    def formatted_trace
+      trace = truncated_trace
+      return "No stack trace available" if trace.empty?
+      
+      trace.map.with_index do |line, index|
+        "#{index}: #{line}"
+      end.join("\n")
+    end
+
+    def full_error_button_dev_only
+      # Only show button in development (not production)
+      return "" if production_mode?
       return "" unless flag_parameter
 
-      payload = full_error_payload
-      return "" unless payload
-
-      button_id = "concise-errors-view-full"
-      payload_id = "#{button_id}-payload"
-      payload_json = ERB::Util.json_escape(JSON.generate(payload))
+      flagged = flagged_url
+      return "" unless flagged
 
       <<~HTML
-        <button type="button" id="#{button_id}">View full Rails error page</button>
-        <script type="application/json" id="#{payload_id}">#{payload_json}</script>
-        <script>
-          (function() {
-            var button = document.getElementById("#{button_id}");
-            var payloadScript = document.getElementById("#{payload_id}");
-            if (!button || !payloadScript) { return; }
-
-            if (!window.fetch) {
-              button.addEventListener("click", function() {
-                window.location.assign("#{html_escape(payload.fetch(:url))}");
-              });
-              return;
-            }
-
-            var payloadText = payloadScript.textContent || payloadScript.innerText || "{}";
-            var data;
-
-            try {
-              data = JSON.parse(payloadText);
-            } catch (error) {
-              console.error("Failed to parse full error request payload", error);
-              return;
-            }
-
-            button.addEventListener("click", function(event) {
-              event.preventDefault();
-
-              var options = {
-                method: data.method,
-                credentials: "same-origin"
-              };
-
-              if (data.headers && Object.keys(data.headers).length > 0) {
-                options.headers = data.headers;
-              }
-
-              if (data.body && data.body.length > 0 && data.method !== "GET" && data.method !== "HEAD") {
-                options.body = data.body;
-              }
-
-              fetch(data.url, options).then(function(response) {
-                return response.text().then(function(html) {
-                  var doc = document;
-                  doc.open();
-                  doc.write(html);
-                  doc.close();
-                });
-              }).catch(function(error) {
-                console.error("Failed to load full Rails error page", error);
-              });
-            });
-          })();
-        </script>
+        <button type="button" onclick="window.location.href='#{html_escape(flagged)}'">
+          Show original error page
+        </button>
       HTML
     end
 
-    def full_error_payload
-      return unless flagged_url
-
-      {
-        method: request.request_method,
-        url: flagged_url,
-        body: replay_body,
-        headers: replay_headers
-      }
-    end
-
-    def replay_body
-      return "" if %w[GET HEAD].include?(request.request_method)
-
-      request.raw_post.to_s
-    rescue EOFError
-      ""
-    end
-
-    def replay_headers
-      headers = {}
-      content_type = request.get_header("CONTENT_TYPE").to_s
-      headers["Content-Type"] = content_type unless content_type.empty?
-
-      csrf = request.get_header("HTTP_X_CSRF_TOKEN").to_s
-      headers["X-CSRF-Token"] = csrf unless csrf.empty?
-
-      headers
+    def production_mode?
+      # Check if we're in production mode
+      return true if configuration.enable_in_production?
+      
+      # Also check Rails.env if available
+      if defined?(Rails) && Rails.respond_to?(:env)
+        return Rails.env.production?
+      end
+      
+      false
     end
 
     def flagged_url
@@ -212,6 +181,191 @@ module ConciseErrors
 
       string = value.to_s.strip
       string.empty? ? nil : string
+    end
+
+    def code_context_section
+      context = extract_code_context
+      return "" unless context
+
+      <<~HTML
+        <div class="code-context">
+          <h2>#{html_escape(context[:file])}:#{context[:line]}</h2>
+          <pre class="code">#{render_code_lines(context)}</pre>
+        </div>
+      HTML
+    end
+
+    def extract_code_context
+      trace_lines = raw_trace
+      return nil if trace_lines.empty?
+
+      first_line = trace_lines.first
+      # Parse format like: "app/controllers/debug_controller.rb:5:in `test_error'"
+      match = first_line.match(/^(.+?):(\d+)(?::in|$)/)
+      return nil unless match
+
+      file_path = match[1]
+      line_number = match[2].to_i
+      
+      # Resolve relative path from application root
+      root = configuration.application_root.to_s
+      full_path = file_path.start_with?("/") ? file_path : File.join(root, file_path)
+      
+      return nil unless File.exist?(full_path)
+
+      {
+        file: file_path,
+        line: line_number,
+        full_path: full_path
+      }
+    rescue StandardError
+      nil
+    end
+
+    def render_code_lines(context)
+      lines = File.readlines(context[:full_path])
+      target_line = context[:line]
+      
+      # Show 3 lines before and after
+      start_line = [target_line - 3, 1].max
+      end_line = [target_line + 3, lines.length].min
+      
+      (start_line..end_line).map do |line_num|
+        line_content = lines[line_num - 1].chomp
+        if line_num == target_line
+          "<span class=\"error-line\">#{line_num}: #{html_escape(line_content)}</span>"
+        else
+          "#{line_num}: #{html_escape(line_content)}"
+        end
+      end.join("\n")
+    rescue StandardError
+      ""
+    end
+
+    def error_page_styles
+      <<~CSS
+        <style>
+          * { margin: 0; padding: 0; box-sizing: border-box; }
+          
+          body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            background: #f8f9fa;
+            padding: 20px;
+          }
+          
+          .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+            overflow: hidden;
+          }
+          
+          .error-header {
+            background: linear-gradient(135deg, #dc3545 0%, #c82333 100%);
+            color: white;
+            padding: 30px;
+            border-bottom: 4px solid #bd2130;
+          }
+          
+          .error-header h1 {
+            font-size: 28px;
+            font-weight: 600;
+            margin-bottom: 10px;
+          }
+          
+          .error-message {
+            font-size: 18px;
+            margin-bottom: 10px;
+            opacity: 0.95;
+          }
+          
+          .status-line {
+            font-size: 14px;
+            opacity: 0.8;
+            font-family: "SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas, "Courier New", monospace;
+          }
+          
+          .code-context, .trace-section {
+            padding: 30px;
+          }
+          
+          .code-context {
+            background: #f8f9fa;
+            border-bottom: 1px solid #dee2e6;
+          }
+          
+          h2 {
+            font-size: 16px;
+            font-weight: 600;
+            margin-bottom: 15px;
+            color: #495057;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+          }
+          
+          pre {
+            background: #2d2d2d;
+            color: #f8f8f2;
+            padding: 20px;
+            border-radius: 6px;
+            overflow-x: auto;
+            font-family: "SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas, "Courier New", monospace;
+            font-size: 14px;
+            line-height: 1.5;
+          }
+          
+          pre.code {
+            background: #1e1e1e;
+            border-left: 4px solid #dc3545;
+          }
+          
+          .error-line {
+            background: #dc354520;
+            display: block;
+            margin: 0 -20px;
+            padding: 0 20px;
+            border-left: 4px solid #dc3545;
+          }
+          
+          pre.trace {
+            background: #2d2d2d;
+            max-height: 400px;
+            overflow-y: auto;
+          }
+          
+          button {
+            background: #007bff;
+            color: white;
+            border: none;
+            padding: 12px 24px;
+            font-size: 14px;
+            font-weight: 500;
+            border-radius: 6px;
+            cursor: pointer;
+            margin: 0 30px 30px 30px;
+            transition: background 0.2s;
+          }
+          
+          button:hover {
+            background: #0056b3;
+          }
+          
+          button:active {
+            transform: translateY(1px);
+          }
+          
+          @media (max-width: 768px) {
+            body { padding: 10px; }
+            .container { border-radius: 0; }
+            .error-header, .code-context, .trace-section { padding: 20px; }
+            pre { font-size: 12px; padding: 15px; }
+          }
+        </style>
+      CSS
     end
   end
 end

--- a/lib/concise_errors/show_exceptions.rb
+++ b/lib/concise_errors/show_exceptions.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "action_dispatch/middleware/show_exceptions"
+require "action_dispatch/middleware/debug_exceptions"
+
+module ConciseErrors
+  # Replacement middleware for production that renders concise error pages instead of generic 500 pages.
+  class ShowExceptions < ::ActionDispatch::ShowExceptions
+    def initialize(app, exceptions_app = nil)
+      @original_exceptions_app = exceptions_app
+      @app = app
+      super(app, exceptions_app || method(:render_concise_exception))
+    end
+
+    def call(env)
+      request = ActionDispatch::Request.new(env)
+      
+      # If full error page is requested, use DebugExceptions to render it
+      if full_error_requested?(request)
+        return debug_exceptions_middleware.call(env)
+      end
+
+      super
+    end
+
+    private
+
+    def render_concise_exception(env)
+      request = ActionDispatch::Request.new(env)
+      wrapper = build_wrapper(env)
+
+      formatter = Formatter.new(wrapper, request, ConciseErrors.configuration)
+      
+      [
+        wrapper.status_code,
+        { "Content-Type" => formatter.content_type },
+        [formatter.body]
+      ]
+    end
+
+    def build_wrapper(env)
+      exception = env["action_dispatch.exception"]
+      backtrace_cleaner = env["action_dispatch.backtrace_cleaner"] || ConciseErrors.configuration.cleaner
+      
+      # Ensure we have backtrace cleaner
+      unless backtrace_cleaner
+        backtrace_cleaner = if defined?(Rails) && Rails.respond_to?(:backtrace_cleaner)
+                              Rails.backtrace_cleaner
+                            else
+                              nil
+                            end
+      end
+      
+      ActionDispatch::ExceptionWrapper.new(backtrace_cleaner, exception)
+    end
+
+    def full_error_requested?(request)
+      flag = ConciseErrors.configuration.full_error_param
+      return false if flag.nil? || flag.to_s.empty?
+
+      request.query_parameters.key?(flag.to_s)
+    end
+
+    def debug_exceptions_middleware
+      # Use Rails' DebugExceptions to show the full error page
+      @debug_exceptions_middleware ||= begin
+        debug_ex = ::ActionDispatch::DebugExceptions.new(@app)
+        
+        # If WebConsole is available, wrap it
+        if defined?(WebConsole::Middleware)
+          WebConsole::Middleware.new(debug_ex)
+        else
+          debug_ex
+        end
+      end
+    end
+  end
+end
+

--- a/test/concise_errors_debug_exceptions_test.rb
+++ b/test/concise_errors_debug_exceptions_test.rb
@@ -36,19 +36,20 @@ class ConciseErrorsDebugExceptionsTest < Minitest::Test
 
     payload = response_body_string(body)
 
-    assert_includes payload, "<pre>"
-    assert_includes payload, "RuntimeError: bang"
-    refute_includes payload, "color-scheme"
+    assert_includes payload, "<!DOCTYPE html>"
+    assert_includes payload, "<h1>RuntimeError</h1>"
+    assert_includes payload, "bang"
+    assert_includes payload, "Stack Trace"
   end
 
-  def test_html_output_includes_full_error_button
+  def test_html_output_includes_full_error_button_in_dev
     ConciseErrors.configure { |config| config.format = :html }
 
     _status, _headers, body = middleware.call(build_env)
 
     payload = response_body_string(body)
 
-    assert_includes payload, 'id="concise-errors-view-full"'
+    assert_includes payload, "Show original error page"
     assert_includes payload, "concise_errors_full=1"
   end
 


### PR DESCRIPTION
Had a use case where we needed to enable visibilty into concise errors in prod apps

This also resolves https://github.com/obie/concise_errors/issues/1
